### PR TITLE
Removed invalid import

### DIFF
--- a/inmemorystorage/storage.py
+++ b/inmemorystorage/storage.py
@@ -20,7 +20,6 @@ from django.core.files.storage import Storage
 from django.core.files.base import ContentFile
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import filepath_to_uri
-from django.utils.six.moves.urllib.parse import urljoin
 from django.utils import timezone
 
 


### PR DESCRIPTION
Removed a reference to django.utils.six.moves.urllib.parse.urljoin that had already been replaced but apparently accidentally left in the file. This was breaking Django3 which has eliminated that module.